### PR TITLE
Multiple fcgi workers + cache

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,18 +3,17 @@ FROM emarcs/debian-minit:jessie
 MAINTAINER Marco Pompili "docker@emarcs.org"
 
 RUN apt-get -qq update && \
-    apt-get -qy install gettext-base && \
-    apt-get -qy install fcgiwrap git cgit highlight && \
-    apt-get -qy install ca-certificates nginx gettext-base && \
-    apt-get -qy install markdown python-docutils groff
-
-RUN apt-get clean && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
+    apt-get -qy install gettext-base \
+                        fcgiwrap git cgit highlight \
+                        ca-certificates nginx gettext-base \
+                        markdown python-docutils groff && \
+    apt-get clean && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 
 RUN useradd nginx
 
 # forward request and error logs to docker log collector
 RUN ln -sf /dev/stdout /var/log/nginx/access.log \
-	&& ln -sf /dev/stderr /var/log/nginx/error.log
+    && ln -sf /dev/stderr /var/log/nginx/error.log
 
 EXPOSE 80 443
 
@@ -37,3 +36,4 @@ ENV CGIT_TITLE "My cgit interface"
 ENV CGIT_DESC "Super fast interface to my git repositories"
 ENV CGIT_VROOT "/"
 ENV CGIT_SECTION_FROM_STARTPATH 0
+

--- a/Dockerfile
+++ b/Dockerfile
@@ -20,6 +20,7 @@ EXPOSE 80 443
 RUN mkdir /srv/git
 
 VOLUME ["/srv/git"]
+VOLUME ["/var/cache/cgit"]
 
 COPY cgitrc.template /etc/
 

--- a/README.md
+++ b/README.md
@@ -20,13 +20,12 @@ Then wait for docker to do its magic.
 
 To launch the container, just the run command like this:
 
-```shell
-
-docker run -d -p 2340:80 \
-  --name nginx-git-srv \
-  -v /git:/srv/git \
-  emarcs/nginx-git
-
+```sh
+docker run -d \
+           -p 2340:80 \
+           --name nginx-git-srv \
+           -v /git:/srv/git \
+           emarcs/nginx-git
 ```
 
 In the above example the **/git** folder of the the host
@@ -38,7 +37,7 @@ the HTTP port is mapped on the host on port **2340**.
 An example using docker-compose of how to mount a custom
 configuration for Nginx:
 
-```ymp
+```yml
 test_srv:
   image: emarcs/nginx-cgit
   ports:
@@ -54,3 +53,19 @@ test_srv:
     # check section-from-path in cgit docs
     CGIT_SECTION_FROM_STARTPATH: 0
 ```
+
+### Cache
+
+cgit provides a cache mechanism (cf https://git.zx2c4.com/cgit/tree/cgitrc.5.txt ), which will
+by default store entries in `/var/cache/cgit`.
+
+You can eventually map this folder to your disk:
+```sh
+docker run -d \
+           -p 2340:80 \
+           --name nginx-git-srv \
+           -v /git:/srv/git \
+           -v /mnt/disk/cgit/cache:/var/cache/cgit \
+           emarcs/nginx-git
+```
+

--- a/cgitrc.template
+++ b/cgitrc.template
@@ -45,6 +45,10 @@ readme=:install
 css=/cgit-css/cgit.css
 logo=/cgit-css/cgit.png
 
+# Cache
+cache-root=/var/cache/cgit
+cache-size=1000
+
 enable-index-links=1
 enable-index-owner=0
 enable-remote-branches=1

--- a/startup
+++ b/startup
@@ -2,8 +2,13 @@
 
 CGIT_VARS='$CGIT_TITLE:$CGIT_DESC:$CGIT_VROOT:$CGIT_SECTION_FROM_STARTPATH'
 
+# Number of fcgi workers
+if [ -z "$FCGI_CHILDREN" ]; then
+    FCGI_CHILDREN=$(nproc)
+fi
+
 envsubst "$CGIT_VARS" < /etc/cgitrc.template > /etc/cgitrc
 
-/usr/bin/spawn-fcgi -M 666 -s /var/run/fcgiwrap.socket /usr/sbin/fcgiwrap
+/usr/bin/spawn-fcgi -F $FCGI_CHILDREN -M 666 -s /var/run/fcgiwrap.socket /usr/sbin/fcgiwrap
 
 /usr/sbin/nginx -g "daemon off;"


### PR DESCRIPTION
Hi,

I faced some issues while deploying your image, nothing critical though:
- concurrency: cgit was not responding on the first heavy request, provided some more fcgi workers for that issue (same as number of CPU)
- no `/var/cache/cgit` directory, so cgit could not use its cache mechanism

Thanks
